### PR TITLE
🐜 fix(runner): Fix Pacman failing to install packages on Amazon Linux 2

### DIFF
--- a/containers/runner.Containerfile
+++ b/containers/runner.Containerfile
@@ -74,7 +74,7 @@ RUN  sed -i '/#\[multilib\]/,/#Include = \/etc\/pacman.d\/mirrorlist/ s/#//' /et
     pacman --noconfirm -Syu archlinux-keyring && \
     dirmngr </dev/null > /dev/null 2>&1 && \
     # Install mesa-git before Steam for simplicity
-    pacman --noconfirm -Sy mesa-git && \
+    pacman --noconfirm -Sy mesa && \
     # Install Steam
     pacman --noconfirm -Sy steam steam-native-runtime && \
     # Clean up pacman cache

--- a/containers/runner.Containerfile
+++ b/containers/runner.Containerfile
@@ -71,7 +71,7 @@ FROM ${BASE_IMAGE} AS runtime
 ## Install Graphics, Media, and Audio packages ##
 RUN  sed -i '/#\[multilib\]/,/#Include = \/etc\/pacman.d\/mirrorlist/ s/#//' /etc/pacman.conf && \
     sed -i "s/#Color/Color/" /etc/pacman.conf && \
-    pacman --noconfirm -Sy archlinux-keyring && \
+    pacman --noconfirm -Syu archlinux-keyring && \
     dirmngr </dev/null > /dev/null 2>&1 && \
     # Install mesa-git before Steam for simplicity
     pacman --noconfirm -Sy mesa-git && \

--- a/containers/runner.Containerfile
+++ b/containers/runner.Containerfile
@@ -1,5 +1,5 @@
 # Container build arguments #
-ARG BASE_IMAGE=docker.io/cachyos/cachyos-v3:latest
+ARG BASE_IMAGE=docker.io/cachyos/cachyos:latest
 
 #******************************************************************************
 #                                                                                                          nestri-server-builder


### PR DESCRIPTION
CachyOS v3 fails to run pacman while on Amazon Linux 2... causing issues with running our hosted version on ECS

Exact errors:
```bash
[root@2b6cbba9d746 /]# sudo pacman -Syu vim
error: failed to initialize alpm library:
(root: /, dbpath: /var/lib/pacman/)
could not find or read directory
```