### PR TITLE
🐜 fix(scripts): Use class codes to check for lspci GPU devices

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -7,6 +7,7 @@ on:
         paths:
             - "containers/runner.Containerfile"
             - "packages/server/**"
+            - "packages/scripts/**"
             - ".github/workflows/runner.yml"
     schedule:
         - cron: 7 0 * * 1,3,6 # Regularly to keep that build cache warm

--- a/containers/runner.Containerfile
+++ b/containers/runner.Containerfile
@@ -160,6 +160,7 @@ ENV XDG_RUNTIME_DIR=/run/user/${UID} \
 
 # Required for NVIDIA.. they want to be special like that #
 ENV NVIDIA_DRIVER_CAPABILITIES=all
+ENV NVIDIA_VISIBLE_DEVICES=all
 
 # DBus run directory creation #
 RUN mkdir -p /run/dbus

--- a/packages/scripts/entrypoint.sh
+++ b/packages/scripts/entrypoint.sh
@@ -36,19 +36,16 @@ source /etc/nestri/gpu_helpers.sh
 
 get_gpu_info
 
-# Identify vendor
-if [[ "${vendor_full_map[0],,}" =~ "intel" ]]; then
-    echo "Intel GPU detected, installing required packages..."
-    #chwd -a
-    pacman -Sy --noconfirm gstreamer-vaapi gst-plugin-va gst-plugin-qsv
-    # chwd missed a thing
-    pacman -Sy --noconfirm vpl-gpu-rt
-elif [[ "${vendor_full_map[0],,}" =~ "amd" ]]; then
-    echo "AMD GPU detected, installing required packages..."
-    #chwd -a
-    pacman -Sy --noconfirm gstreamer-vaapi gst-plugin-va
-elif [[ "${vendor_full_map[0],,}" =~ "nvidia" ]]; then
+# Check vendors in priority order
+if [[ -n "${vendor_devices[nvidia]:-}" ]]; then
     echo "NVIDIA GPU detected. Assuming drivers are linked"
+elif [[ -n "${vendor_devices[intel]:-}" ]]; then
+    echo "Intel GPU detected, installing required packages..."
+    pacman -Sy --noconfirm gstreamer-vaapi gst-plugin-va gst-plugin-qsv
+    pacman -Sy --noconfirm vpl-gpu-rt
+elif [[ -n "${vendor_devices[amd]:-}" ]]; then
+    echo "AMD GPU detected, installing required packages..."
+    pacman -Sy --noconfirm gstreamer-vaapi gst-plugin-va
 else
     echo "Unknown GPU vendor. No additional packages will be installed"
 fi

--- a/packages/scripts/gpu_helpers.sh
+++ b/packages/scripts/gpu_helpers.sh
@@ -11,8 +11,8 @@ function get_gpu_info {
     vendor_id_map=()
     vendor_index_map=()
 
-    # Use lspci to detect GPU info
-    gpu_info=$(lspci | grep -i 'vga\|3d\|display')
+    # Use lspci to detect GPU info, using class codes for VGA, 3D and Display
+    gpu_info=$(lspci -nn | grep -E '\<(0300|0302|0380)\>')
 
     # Parse each line of GPU info
     while IFS= read -r line; do

--- a/packages/scripts/gpu_helpers.sh
+++ b/packages/scripts/gpu_helpers.sh
@@ -1,52 +1,47 @@
 #!/bin/bash
 set -euo pipefail
 
-declare -a vendor_full_map=()
-declare -a vendor_id_map=()
-declare -A vendor_index_map=()
+declare -A vendor_devices=()
 
 function get_gpu_info {
-    # Initialize arrays/maps to avoid unbound variable errors
-    vendor_full_map=()
-    vendor_id_map=()
-    vendor_index_map=()
+    vendor_devices=()
 
-    # Use lspci to detect GPU info, using class codes for VGA, 3D and Display
-    gpu_info=$(lspci -nn | grep -E '\<(0300|0302|0380)\>')
+    local gpu_info=$(lspci -nn | grep -E '\<(0300|0302|0380)\>')
 
-    # Parse each line of GPU info
     while IFS= read -r line; do
-        # Extract vendor name and ID from lspci output
-        vendor=$(echo "$line" | awk -F: '{print $3}' | sed -E 's/^[[:space:]]+//g' | tr '[:upper:]' '[:lower:]')
-        id=$(echo "$line" | awk '{print $1}')
+        # Extract vendor_id from [vendor_id:device_id]
+        local vendor_id=$(echo "$line" | sed -nE 's/.*\[([[:xdigit:]]{4}):[[:xdigit:]]{4}\].*/\1/p' | tr '[:upper:]' '[:lower:]')
+        local id=$(echo "$line" | awk '{print $1}')
 
-        # Normalize vendor name
-        if [[ $vendor =~ .*nvidia.* ]]; then
-            vendor="nvidia"
-        elif [[ $vendor =~ .*intel.* ]]; then
-            vendor="intel"
-        elif [[ $vendor =~ .*advanced[[:space:]]micro[[:space:]]devices.* ]]; then
-            vendor="amd"
-        elif [[ $vendor =~ .*ati.* ]]; then
-            vendor="amd"
-        else
-            vendor="unknown"
-        fi
+        # Map vendor_id to known vendors
+        local vendor="unknown"
+        case "$vendor_id" in
+        10de) vendor="nvidia" ;;
+        8086) vendor="intel" ;;
+        1002 | 1022) vendor="amd" ;;
+            # Add other vendor IDs as needed
+        esac
 
-        # Add to arrays/maps if unique
-        if ! [[ "${vendor_index_map[$vendor]:-}" ]]; then
-            vendor_index_map[$vendor]="${#vendor_full_map[@]}"
-            vendor_full_map+=("$vendor")
+        if [[ "$vendor" != "unknown" ]]; then
+            vendor_devices["$vendor"]+="$id "
         fi
-        vendor_id_map+=("$id")
-    done <<< "$gpu_info"
+    done <<<"$gpu_info"
 }
 
 function debug_gpu_info {
-    echo "Vendor Full Map: ${vendor_full_map[*]}"
-    echo "Vendor ID Map: ${vendor_id_map[*]}"
-    echo "Vendor Index Map:"
-    for key in "${!vendor_index_map[@]}"; do
-        echo "  $key: ${vendor_index_map[$key]}"
+    echo "Detected GPUs:"
+    for vendor in "${!vendor_devices[@]}"; do
+        echo "  $vendor: ${vendor_devices[$vendor]}"
     done
 }
+
+# # Usage example:
+# get_gpu_info
+# debug_gpu_info
+
+# # Access NVIDIA GPUs specifically
+# if [[ -n "${vendor_devices[nvidia]:-}" ]]; then
+#     echo "NVIDIA GPUs detected: ${vendor_devices[nvidia]}"
+# else
+#     echo "No NVIDIA GPUs found"
+# fi


### PR DESCRIPTION
Fixes gpu_helpers returning "Non-VGA" devices as GPUs.

I was curious about DeepSeek's so I tried it's hand with this as my head isn't quite up-to-speed yet :sweat_smile:
But yeah it seems less error-prone than previous naive string-approach.