### PR TITLE
🐜 fix(runner): Improve NVIDIA driver handling, switch to gamescope

### DIFF
--- a/containers/runner.Containerfile
+++ b/containers/runner.Containerfile
@@ -132,9 +132,11 @@ RUN sed -i \
 # Core system components
 RUN --mount=type=cache,target=/var/cache/pacman/pkg \
     pacman -Sy --needed --noconfirm \
-        vulkan-intel lib32-vulkan-intel vpl-gpu-rt mesa \
+        vulkan-intel lib32-vulkan-intel vpl-gpu-rt \
+        vulkan-radeon lib32-vulkan-radeon \
+        mesa \
         steam steam-native-runtime gtk3 lib32-gtk3 \
-        sudo xorg-xwayland seatd libinput labwc wlr-randr gamescope mangohud \
+        sudo xorg-xwayland seatd libinput gamescope mangohud \
         libssh2 curl wget \
         pipewire pipewire-pulse pipewire-alsa wireplumber \
         noto-fonts-cjk supervisor jq chwd lshw pacman-contrib && \

--- a/packages/scripts/envs.sh
+++ b/packages/scripts/envs.sh
@@ -2,13 +2,15 @@
 set -euo pipefail
 
 export XDG_RUNTIME_DIR=/run/user/${UID}/
-export WAYLAND_DISPLAY=wayland-0
-export XDG_SESSION_TYPE=wayland
+export XDG_SESSION_TYPE=x11
 export DISPLAY=:0
 export $(dbus-launch)
 
 # Causes some setups to break
 export PROTON_NO_FSYNC=1
+
+# Sleeker Mangohud preset :)
+export MANGOHUD_CONFIG=preset=2
 
 # Our preferred prefix
 export WINEPREFIX=/home/${USER}/.nestripfx/

--- a/packages/server/src/gpu.rs
+++ b/packages/server/src/gpu.rs
@@ -84,7 +84,7 @@ pub fn get_gpus() -> Vec<GPUInfo> {
 
 fn parse_pci_device(line: &str) -> Option<(String, String, String, String)> {
     let re = Regex::new(
-        r#"^(?P<pci_addr>\S+)\s+"[^\[]*\[(?P<class_id>[0-9a-f]{4})\].*?"\s+"[^\[]*\[(?P<vendor_id>[0-9a-f]{4})\].*?"\s+"(?P<device_name>[^"]+?)""#,
+        r#"^(?P<pci_addr>\S+)\s+"[^\[]*\[(?P<class_id>[0-9a-f]{4})\].*?"\s+"[^"]*?\[(?P<vendor_id>[0-9a-f]{4})\][^"]*?"\s+"(?P<device_name>[^"]+?)""#,
     ).unwrap();
 
     let caps = re.captures(line)?;


### PR DESCRIPTION
## Description
- Made it so failed NVIDIA driver install won't quit entrypoint script if other GPU vendors are present (fixes mixed GPU cases).
- Switch to gamescope as compositor, with optional SYS_NICE cap handling for higher priority.
- Use mangohud preset 2 for stats, which is more compact.
- Fixes to nestri-server lspci regex, to deal with AMD naming scheme.
- Added missing radeon vulkan driver packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for additional AMD Vulkan drivers.
	- Integrated Steam launch directly within the gamescope compositor for a streamlined startup.

- **Bug Fixes**
	- Improved GPU driver fallback handling to ensure smoother operation on systems without NVIDIA GPUs.
	- Enhanced PCI device parsing for more accurate GPU detection.

- **Chores**
	- Updated environment configuration to use X11 session type and set MangoHud preset.
	- Removed unused packages and legacy compositor/resolution management logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->