### PR TITLE
🐜 fix(zero): Remove team and members schemas

### DIFF
--- a/packages/core/migrations/0025_bitter_jack_flag.sql
+++ b/packages/core/migrations/0025_bitter_jack_flag.sql
@@ -1,0 +1,3 @@
+DROP TABLE "members" CASCADE;--> statement-breakpoint
+DROP TABLE "teams" CASCADE;--> statement-breakpoint
+DROP TYPE "public"."member_role";

--- a/packages/core/migrations/meta/0025_snapshot.json
+++ b/packages/core/migrations/meta/0025_snapshot.json
@@ -1,0 +1,930 @@
+{
+  "id": "735d315b-40e1-46c1-814d-0fd3619b65de",
+  "prevId": "d35aa09b-5739-46a5-86f3-3050913dc2f7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.base_games": {
+      "name": "base_games",
+      "schema": "",
+      "columns": {
+        "time_created": {
+          "name": "time_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_updated": {
+          "name": "time_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_deleted": {
+          "name": "time_deleted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "links": {
+          "name": "links",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_genre": {
+          "name": "primary_genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller_support": {
+          "name": "controller_support",
+          "type": "controller_support",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compatibility": {
+          "name": "compatibility",
+          "type": "compatibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(2, 1)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_base_games_slug": {
+          "name": "idx_base_games_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "time_created": {
+          "name": "time_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_updated": {
+          "name": "time_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_deleted": {
+          "name": "time_deleted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "category_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_categories_type": {
+          "name": "idx_categories_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "categories_slug_type_pk": {
+          "name": "categories_slug_type_pk",
+          "columns": [
+            "slug",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.friends_list": {
+      "name": "friends_list",
+      "schema": "",
+      "columns": {
+        "time_created": {
+          "name": "time_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_updated": {
+          "name": "time_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_deleted": {
+          "name": "time_deleted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_id": {
+          "name": "steam_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_steam_id": {
+          "name": "friend_steam_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_friends_list_friend_steam_id": {
+          "name": "idx_friends_list_friend_steam_id",
+          "columns": [
+            {
+              "expression": "friend_steam_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "friends_list_steam_id_steam_accounts_id_fk": {
+          "name": "friends_list_steam_id_steam_accounts_id_fk",
+          "tableFrom": "friends_list",
+          "tableTo": "steam_accounts",
+          "columnsFrom": [
+            "steam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "friends_list_friend_steam_id_steam_accounts_id_fk": {
+          "name": "friends_list_friend_steam_id_steam_accounts_id_fk",
+          "tableFrom": "friends_list",
+          "tableTo": "steam_accounts",
+          "columnsFrom": [
+            "friend_steam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "friends_list_steam_id_friend_steam_id_pk": {
+          "name": "friends_list_steam_id_friend_steam_id_pk",
+          "columns": [
+            "steam_id",
+            "friend_steam_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "time_created": {
+          "name": "time_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_updated": {
+          "name": "time_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_deleted": {
+          "name": "time_deleted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_game_id": {
+          "name": "base_game_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_slug": {
+          "name": "category_slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "category_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_games_category_slug": {
+          "name": "idx_games_category_slug",
+          "columns": [
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_games_category_type": {
+          "name": "idx_games_category_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_games_category_slug_type": {
+          "name": "idx_games_category_slug_type",
+          "columns": [
+            {
+              "expression": "category_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "games_base_game_id_base_games_id_fk": {
+          "name": "games_base_game_id_base_games_id_fk",
+          "tableFrom": "games",
+          "tableTo": "base_games",
+          "columnsFrom": [
+            "base_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "games_categories_fkey": {
+          "name": "games_categories_fkey",
+          "tableFrom": "games",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_slug",
+            "type"
+          ],
+          "columnsTo": [
+            "slug",
+            "type"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "games_base_game_id_category_slug_type_pk": {
+          "name": "games_base_game_id_category_slug_type_pk",
+          "columns": [
+            "base_game_id",
+            "category_slug",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "time_created": {
+          "name": "time_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_updated": {
+          "name": "time_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_deleted": {
+          "name": "time_deleted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "image_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_hash": {
+          "name": "image_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_game_id": {
+          "name": "base_game_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_color": {
+          "name": "extracted_color",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_images_type": {
+          "name": "idx_images_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_images_game_id": {
+          "name": "idx_images_game_id",
+          "columns": [
+            {
+              "expression": "base_game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "images_base_game_id_base_games_id_fk": {
+          "name": "images_base_game_id_base_games_id_fk",
+          "tableFrom": "images",
+          "tableTo": "base_games",
+          "columnsFrom": [
+            "base_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "images_image_hash_type_base_game_id_position_pk": {
+          "name": "images_image_hash_type_base_game_id_position_pk",
+          "columns": [
+            "image_hash",
+            "type",
+            "base_game_id",
+            "position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_libraries": {
+      "name": "game_libraries",
+      "schema": "",
+      "columns": {
+        "time_created": {
+          "name": "time_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_updated": {
+          "name": "time_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_deleted": {
+          "name": "time_deleted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_game_id": {
+          "name": "base_game_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_steam_id": {
+          "name": "owner_steam_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_played": {
+          "name": "last_played",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_playtime": {
+          "name": "total_playtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_game_libraries_owner_id": {
+          "name": "idx_game_libraries_owner_id",
+          "columns": [
+            {
+              "expression": "owner_steam_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_libraries_base_game_id_base_games_id_fk": {
+          "name": "game_libraries_base_game_id_base_games_id_fk",
+          "tableFrom": "game_libraries",
+          "tableTo": "base_games",
+          "columnsFrom": [
+            "base_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_libraries_owner_steam_id_steam_accounts_id_fk": {
+          "name": "game_libraries_owner_steam_id_steam_accounts_id_fk",
+          "tableFrom": "game_libraries",
+          "tableTo": "steam_accounts",
+          "columnsFrom": [
+            "owner_steam_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_libraries_base_game_id_owner_steam_id_pk": {
+          "name": "game_libraries_base_game_id_owner_steam_id_pk",
+          "columns": [
+            "base_game_id",
+            "owner_steam_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.steam_accounts": {
+      "name": "steam_accounts",
+      "schema": "",
+      "columns": {
+        "time_created": {
+          "name": "time_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_updated": {
+          "name": "time_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_deleted": {
+          "name": "time_deleted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "char(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "steam_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_since": {
+          "name": "member_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_hash": {
+          "name": "avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limitations": {
+          "name": "limitations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "steam_accounts_user_id_users_id_fk": {
+          "name": "steam_accounts_user_id_users_id_fk",
+          "tableFrom": "steam_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(30)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "time_created": {
+          "name": "time_created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_updated": {
+          "name": "time_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_deleted": {
+          "name": "time_deleted",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polar_customer_id": {
+          "name": "polar_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.compatibility": {
+      "name": "compatibility",
+      "schema": "public",
+      "values": [
+        "high",
+        "mid",
+        "low",
+        "unknown"
+      ]
+    },
+    "public.controller_support": {
+      "name": "controller_support",
+      "schema": "public",
+      "values": [
+        "full",
+        "partial",
+        "unknown"
+      ]
+    },
+    "public.category_type": {
+      "name": "category_type",
+      "schema": "public",
+      "values": [
+        "tag",
+        "genre",
+        "publisher",
+        "developer",
+        "categorie",
+        "franchise"
+      ]
+    },
+    "public.image_type": {
+      "name": "image_type",
+      "schema": "public",
+      "values": [
+        "heroArt",
+        "icon",
+        "logo",
+        "banner",
+        "poster",
+        "boxArt",
+        "screenshot",
+        "backdrop"
+      ]
+    },
+    "public.steam_status": {
+      "name": "steam_status",
+      "schema": "public",
+      "values": [
+        "online",
+        "offline",
+        "dnd",
+        "playing"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/migrations/meta/_journal.json
+++ b/packages/core/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1748414049463,
       "tag": "0024_damp_cerise",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1748845818197,
+      "tag": "0025_bitter_jack_flag",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/zero/schema.ts
+++ b/packages/zero/schema.ts
@@ -1,5 +1,5 @@
-import type { Size, Links} from "@nestri/core/src/base-game/base-game.sql";
 import type { Limitations } from "@nestri/core/src/steam/steam.sql";
+import type { Size, Links } from "@nestri/core/src/base-game/base-game.sql";
 import type { ImageColor, ImageDimensions } from "@nestri/core/src/images/images.sql";
 import {
     json,
@@ -46,27 +46,6 @@ const steam_accounts = table("steam_accounts")
         ...timestamps,
     })
     .primaryKey("id");
-
-const teams = table("teams")
-    .columns({
-        id: string(),
-        name: string(),
-        invite_code: string(),
-        max_members: number(),
-        owner_steam_id: string(),
-        ...timestamps,
-    })
-    .primaryKey("id");
-
-const members = table("members")
-    .columns({
-        role: string(),
-        team_id: string(),
-        steam_id: string(),
-        user_id: string().optional(),
-        ...timestamps,
-    })
-    .primaryKey("team_id", "steam_id");
 
 const friends_list = table("friends_list")
     .columns({
@@ -130,27 +109,17 @@ const images = table("images")
         dimensions: json<ImageDimensions>(),
         extracted_color: json<ImageColor>(),
         ...timestamps
-    }).primaryKey("image_hash", "type", "base_game_id", "position")
+    }).primaryKey("image_hash")
 
 // Schema and Relationships
 export const schema = createSchema({
-    tables: [users, steam_accounts, teams, members, friends_list, categories, base_games, games, game_libraries, images],
+    tables: [users, steam_accounts, friends_list, categories, base_games, games, game_libraries, images],
     relationships: [
         relationships(steam_accounts, (r) => ({
             user: r.one({
                 sourceField: ["user_id"],
                 destSchema: users,
                 destField: ["id"],
-            }),
-            memberEntries: r.many({
-                sourceField: ["id"],
-                destSchema: members,
-                destField: ["steam_id"],
-            }),
-            teams: r.many({
-                sourceField: ["id"],
-                destSchema: teams,
-                destField: ["owner_steam_id"],
             }),
             friends: r.many(
                 {
@@ -178,45 +147,11 @@ export const schema = createSchema({
             ),
         })),
         relationships(users, (r) => ({
-            members: r.many({
-                sourceField: ["id"],
-                destSchema: members,
-                destField: ["user_id"],
-            }),
             steamAccounts: r.many({
                 sourceField: ["id"],
                 destSchema: steam_accounts,
                 destField: ["user_id"]
             })
-        })),
-        relationships(teams, (r) => ({
-            owner: r.one({
-                sourceField: ["owner_steam_id"],
-                destSchema: steam_accounts,
-                destField: ["id"],
-            }),
-            members: r.many({
-                sourceField: ["id"],
-                destSchema: members,
-                destField: ["team_id"],
-            }),
-        })),
-        relationships(members, (r) => ({
-            team: r.one({
-                sourceField: ["team_id"],
-                destSchema: teams,
-                destField: ["id"],
-            }),
-            user: r.one({
-                sourceField: ["user_id"],
-                destSchema: users,
-                destField: ["id"],
-            }),
-            steamAccount: r.one({
-                sourceField: ["steam_id"],
-                destSchema: steam_accounts,
-                destField: ["id"],
-            }),
         })),
         relationships(base_games, (r) => ({
             libraryOwners: r.many(
@@ -324,30 +259,12 @@ type Auth = {
 
 export const permissions = definePermissions<Auth, Schema>(schema, () => {
     return {
-        members: {
-            row: {
-                select: [
-                    (auth: Auth, q: ExpressionBuilder<Schema, 'members'>) => q.exists("user", (u) => u.where("id", auth.sub)),
-                    //allow other team members to view other members
-                    (auth: Auth, q: ExpressionBuilder<Schema, 'members'>) => q.exists("team", (u) => u.related("members", (m) => m.where("user_id", auth.sub))),
-                ]
-            },
-        },
-        teams: {
-            row: {
-                select: [
-                    (auth: Auth, q: ExpressionBuilder<Schema, 'teams'>) => q.exists("members", (u) => u.where("user_id", auth.sub)),
-                ]
-            },
-        },
         steam_accounts: {
             row: {
                 select: [
                     (auth: Auth, q: ExpressionBuilder<Schema, 'steam_accounts'>) => q.exists("user", (u) => u.where("id", auth.sub)),
                     //Allow friends to view friends steam accounts
                     (auth: Auth, q: ExpressionBuilder<Schema, 'steam_accounts'>) => q.exists("friends", (u) => u.where("user_id", auth.sub)),
-                    //allow other team members to see a user's steam account
-                    (auth: Auth, q: ExpressionBuilder<Schema, 'steam_accounts'>) => q.exists("memberEntries", (u) => u.related("team", (t) => t.related("members", (m) => m.where("user_id", auth.sub)))),
                 ]
             },
         },
@@ -370,8 +287,6 @@ export const permissions = definePermissions<Auth, Schema>(schema, () => {
             row: {
                 select: [
                     (auth: Auth, q: ExpressionBuilder<Schema, 'game_libraries'>) => q.exists("owner", (u) => u.where("user_id", auth.sub)),
-                    //allow team members to see the other members' libraries
-                    (auth: Auth, q: ExpressionBuilder<Schema, 'game_libraries'>) => q.exists("owner", (u) => u.related("memberEntries", (f) => f.where("user_id", auth.sub))),
                     //allow friends to see their friends libraries
                     (auth: Auth, q: ExpressionBuilder<Schema, 'game_libraries'>) => q.exists("owner", (u) => u.related("friends", (f) => f.where("user_id", auth.sub))),
                 ]


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose and scope of your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new database schema with tables for games, users, Steam accounts, categories, friends lists, images, and game libraries.
  - Added new enumerated types for compatibility, controller support, category type, image type, and Steam status.

- **Refactor**
  - Removed all team and membership-related features, including tables, relationships, and access permissions.
  - Simplified the primary key structure of the images table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->